### PR TITLE
Add License to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.5.4",
   "description": "Same as JSON but with added support for `Date`, `undefined`, `Map`, `Set`, and more.",
   "main": "./index.mjs",
+  "license": "MIT",
   "exports": {
     ".": "./index.mjs",
     "./parse": {


### PR DESCRIPTION
relates to #11 

For people that maybe pulling this library through tools like repository proxy to npm, they may wish to only use OSI approved licenses for their software. Since this library already has the MIT license, when pulling from npm, I figured it might be a good idea to have this library's license field reflect that.



https://docs.npmjs.com/cli/v9/configuring-npm/package-json#license