### PR TITLE
fix: exports conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,14 @@
   "exports": {
     ".": "./index.mjs",
     "./parse": {
-      "node": "./dist/cjs/parse.js",
+      "import": "./dist/esm/parse.js",
+      "require": "./dist/cjs/parse.js",
       "types": "./dist/esm/parse.d.ts",
       "default": "./dist/esm/parse.js"
     },
     "./stringify": {
-      "node": "./dist/cjs/stringify.js",
+      "import": "./dist/esm/stringify.js",
+      "require": "./dist/cjs/stringify.js",
       "types": "./dist/esm/stringify.d.ts",
       "default": "./dist/esm/stringify.js"
     }


### PR DESCRIPTION
In Vite SSR, `node` export condition is always used, thus always importing the CJS version. `import` + `require` should be preferred, as they are supported by default by Node/Bun/Deno/Vite (`node` is usually reserved for code with node-specific imports, such as `node:fs` for instance)