### PR TITLE
fix: ESM modules must be imported with file extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.5.18",
   "description": "Same as JSON but with added support for `Date`, `undefined`, `Map`, `Set`, and more.",
   "main": "./index.mjs",
+  "type": "module",
   "exports": {
     ".": "./index.mjs",
     "./parse": {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -2,7 +2,7 @@ export { parse }
 // Used by Vike: https://github.com/vikejs/vike/blob/b4ba6b70e6bdc2e1f460c0d2e4c3faae5d0a733c/vike/shared/page-configs/serialize/parseConfigValuesSerialized.ts#L13
 export { parseTransform }
 
-import { types } from './types'
+import { types } from './types.js'
 
 type Options = {
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#reviver

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -1,11 +1,11 @@
 export { stringify }
 export { isJsonSerializerError }
 
-import { types } from './types'
-import { isReactElement } from './utils/isReactElement'
-import { isCallable } from './utils/isCallable'
-import { isObject } from './utils/isObject'
-import { replacerWithPath, type Iterable, type Path } from './utils/replacerWithPath'
+import { types } from './types.js'
+import { isReactElement } from './utils/isReactElement.js'
+import { isCallable } from './utils/isCallable.js'
+import { isObject } from './utils/isObject.js'
+import { replacerWithPath, type Iterable, type Path } from './utils/replacerWithPath.js'
 
 function stringify(
   value: unknown,

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "outDir": "dist/cjs/",
     "target": "ES2017",
-    "module": "CommonJS"
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "verbatimModuleSyntax": false
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,16 @@
 {
   "compilerOptions": {
     // Output
-    "target": "ES2020",
-    "module": "ES2020",
+    "target": "ES2022",
+    "module": "ES2022",
     "moduleResolution": "Node",
     "outDir": "dist/esm/",
     // User-code
     "strict": true,
     // Source Maps
     "declaration": true,
-    "rootDir": "./src/"
+    "rootDir": "./src/",
+    "verbatimModuleSyntax": true
   },
   "include": ["./src/**/*"]
 }


### PR DESCRIPTION
Without it, we have errors such as:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/magne/workspace/vike-server/node_modules/.pnpm/@brillout+json-serializer@0.5.18/node_modules/@brillout/json-serializer/dist/esm/types' imported from /home/magne/workspace/vike-server/node_modules/.pnpm/@brillout+json-serializer@0.5.18/node_modules/@brillout/json-serializer/dist/esm/stringify.js
```