### PR TITLE
feat: pass path to reviver

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -6,7 +6,7 @@ export type { Reviver }
 import { types } from './types.js'
 
 type Reviver = (
-  key: undefined | string,
+  path: undefined | readonly string[],
   value: string,
   parser: (str: string) => unknown,
 ) => { replacement: unknown; resolved?: boolean } | undefined
@@ -21,9 +21,9 @@ function parse(str: string, options: Options = {}): unknown {
   return parseTransform(value, options)
 }
 
-function parseTransform(value: unknown, options: Options = {}): unknown {
+function parseTransform(value: unknown, options: Options = {}, path?: readonly string[]): unknown {
   if (typeof value === 'string') {
-    return reviver(value, options)
+    return reviver(value, options, path)
   }
   if (
     // Also matches arrays
@@ -31,21 +31,16 @@ function parseTransform(value: unknown, options: Options = {}): unknown {
     value !== null
   ) {
     Object.entries(value).forEach(([key, val]: [string, unknown]) => {
-      ;(value as Record<string, unknown>)[key] = parseTransform(val, options)
+      ;(value as Record<string, unknown>)[key] = parseTransform(val, options, path === undefined ? [key] : [...path, key])
     })
   }
   return value
 }
 
-function reviver(value: string, options: Options): unknown {
+function reviver(value: string, options: Options, path: readonly string[] | undefined): unknown {
   const parser = (str: string) => parse(str, options)
   {
-    const res = options.reviver?.(
-      // TO-DO/eventually: provide key if some user needs it
-      undefined,
-      value,
-      parser,
-    )
+    const res = options.reviver?.(path, value, parser)
     if (res) {
       if (typeof res.replacement !== 'string') {
         return res.replacement

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -6,7 +6,7 @@ export type { Reviver }
 import { types } from './types.js'
 
 type Reviver = (
-  path: undefined | readonly string[],
+  path: readonly string[],
   value: string,
   parser: (str: string) => unknown,
 ) => { replacement: unknown; resolved?: boolean } | undefined
@@ -21,7 +21,7 @@ function parse(str: string, options: Options = {}): unknown {
   return parseTransform(value, options)
 }
 
-function parseTransform(value: unknown, options: Options = {}, path?: readonly string[]): unknown {
+function parseTransform(value: unknown, options: Options = {}, path: readonly string[] = []): unknown {
   if (typeof value === 'string') {
     return reviver(value, options, path)
   }
@@ -31,13 +31,13 @@ function parseTransform(value: unknown, options: Options = {}, path?: readonly s
     value !== null
   ) {
     Object.entries(value).forEach(([key, val]: [string, unknown]) => {
-      ;(value as Record<string, unknown>)[key] = parseTransform(val, options, path === undefined ? [key] : [...path, key])
+      ;(value as Record<string, unknown>)[key] = parseTransform(val, options, [...path, key])
     })
   }
   return value
 }
 
-function reviver(value: string, options: Options, path: readonly string[] | undefined): unknown {
+function reviver(value: string, options: Options, path: readonly string[]): unknown {
   const parser = (str: string) => parse(str, options)
   {
     const res = options.reviver?.(path, value, parser)

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -138,6 +138,44 @@ describe('user-defined reviver', () => {
   })
 })
 
+describe('reviver path', () => {
+  it('receives the path to every revived string', () => {
+    const paths: string[][] = []
+    parse('{"a":{"b":["X","Y"]},"c":"Z"}', {
+      reviver(path) {
+        paths.push([...path])
+        return undefined
+      },
+    })
+    expect(paths).toEqual([
+      ['a', 'b', '0'],
+      ['a', 'b', '1'],
+      ['c'],
+    ])
+  })
+
+  it('root path is []', () => {
+    let captured: readonly string[] | undefined
+    parse('"hello"', {
+      reviver(path) {
+        captured = path
+        return undefined
+      },
+    })
+    expect(captured).toEqual([])
+  })
+
+  it('enables per-position replacement', () => {
+    const result = parse('{"a":"x","b":"x"}', {
+      reviver(path, value) {
+        if (path.join('.') === 'a') return { replacement: `at-a:${value}` }
+        return undefined
+      },
+    })
+    expect(result).toEqual({ a: 'at-a:x', b: 'x' })
+  })
+})
+
 describe('sortObjectKeys option', () => {
   it('works', () => {
     // Basic test


### PR DESCRIPTION
# Pass path to reviver

Resolves the `TO-DO/eventually: provide key if some user needs it` in [src/parse.ts](src/parse.ts).

## What

The `Reviver` callback now receives the path from the document root to the value being revived:

```diff
 type Reviver = (
-  key: undefined | string,
+  path: readonly string[],
   value: string,
   parser: (str: string) => unknown,
 ) => { replacement: unknown; resolved?: boolean } | undefined
```

```js
parse('{"a":{"b":["X","Y"]}}', {
  reviver: (path, value) => {
    // path = ['a','b','0'] for "X"
    // path = ['a','b','1'] for "Y"
  }
})
```

Root value → `path === []`. Array indices are stringified (`'0'`, `'1'`, …), matching `Object.entries`.

## Why

Without a path, a reviver only sees raw values — it can't tell *where* in the input tree it is.

Concrete use case: **telefunc**'s request deserializer. A signature like

```ts
function onUpload(file: File, callbacks: { onProgress: (p: number) => void })
```

has a shield for the callback registered at `['args','1','onProgress']`. When the reviver sees the serialized function placeholder, it needs the path to look up the right validator.

## Notes

- **`[]` for the root**, not `undefined` — the path from root to root is just empty.
- **`readonly string[]`** — stops revivers from mutating the path and leaking state across siblings.
- `parseTransform` gains an optional third parameter defaulting to `[]`; existing external callers (e.g. [Vike](https://github.com/vikejs/vike/blob/b4ba6b70e6bdc2e1f460c0d2e4c3faae5d0a733c/vike/shared/page-configs/serialize/parseConfigValuesSerialized.ts#L13)) are unaffected.

## Compatibility

The `Reviver` first parameter changes type (`undefined | string` → `readonly string[]`). Per the existing comment (`AFAIK it isn't used by anyone yet`), no known reviver inspects this parameter today — it was always `undefined`. Revivers that ignore the parameter keep working.

## Testing

Added three cases under a new `reviver path` block in [test/main.spec.ts](test/main.spec.ts):

- Path is threaded through nested objects and arrays.
- Root value has `path === []`.
- Per-position replacement works end-to-end.

`pnpm test` — 21/21 passing. `pnpm build` — clean.
